### PR TITLE
allow k8-bootstrap to build images if they don't exist

### DIFF
--- a/k8s-bootstrap.sh
+++ b/k8s-bootstrap.sh
@@ -16,12 +16,18 @@ helm repo add signoz https://charts.signoz.io
 kubectl create ns platform
 helm --namespace platform install signoz signoz/signoz
 
-POD_NAME=$(kubectl get pods --namespace platform -l "app.kubernetes.io/name=signoz,app.kubernetes.io/instance=signoz,app.kubernetes.io/component=frontend" -o jsonpath="{.items[0].metadata.name}")
+SIGNOZ_FRONTEND_POD=$(kubectl get pods --namespace platform -l "app.kubernetes.io/name=signoz,app.kubernetes.io/instance=signoz,app.kubernetes.io/component=frontend" -o jsonpath="{.items[0].metadata.name}")
 
-# Apps
+# Build apps if docker images do not exist
+if [[ "$(docker images -q users-api:latest 2> /dev/null)" == "" ]] \
+  || [[ "$(docker images -q orders-api:latest 2> /dev/null)" == "" ]]; then
+  echo "[INFO] App docker images do not exist ~> Building docker images through ./build-containers.sh"
+  sh ./build-containers.sh
+fi
+
 kubectl apply -f k8s/users-api.yml
 kubectl apply -f k8s/orders-api.yml
 
-echo "[INFO] Waiting for signoz pods to be in ready state -> Port forwarding"
-kubectl -n platform wait pod --for=condition=Ready --all --timeout=300s
-kubectl --namespace platform port-forward "$POD_NAME" 3301:3301
+echo "[INFO] Waiting for signoz pod $SIGNOZ_FRONTEND_POD to be in ready state -> Port forwarding"
+kubectl -n platform wait pod --for=condition=Ready "$SIGNOZ_FRONTEND_POD" --timeout=300s
+kubectl --namespace platform port-forward "$SIGNOZ_FRONTEND_POD" 3301:3301


### PR DESCRIPTION
This PR adds checks for the app docker images and builds them if they don't exists, also cleaning up the signoz front-end portforward wait for just the pod that's requires